### PR TITLE
Added option for preventing the checking of parent categories

### DIFF
--- a/widgets/WidgetTreeSelector.php
+++ b/widgets/WidgetTreeSelector.php
@@ -426,12 +426,12 @@ class WidgetTreeSelector extends \Widget
             // Add checkbox or radio button
             switch ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['fieldType']) {
                 case 'checkbox':
-                    $input = '<input type="checkbox" name="' . $this->strName . '[]" id="' . $this->strName . '_' . $id . '" class="tl_tree_checkbox" value="' . specialchars($id) . '" onfocus="Backend.getScrollOffset()"' . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['selectParents'] ? ' onclick="TreePicker.selectParents(this)"' : '') . static::optionChecked($id, $this->varValue) . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['parentsUnselectable'] && !$this->isLeaf($objItem) ? ' disabled="disabled"' : '') . '>';
+                    $input = '<input type="checkbox" name="' . $this->strName . '[]" id="' . $this->strName . '_' . $id . '" class="tl_tree_checkbox" value="' . specialchars($id) . '" onfocus="Backend.getScrollOffset()"' . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['selectParents'] ? ' onclick="TreePicker.selectParents(this)"' : '') . static::optionChecked($id, $this->varValue) . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['parentsUnselectable'] && $this->hasChildren($objItem) ? ' disabled="disabled"' : '') . '>';
                     break;
 
                 default:
                 case 'radio':
-                    $input = '<input type="radio" name="' . $this->strName . '" id="' . $this->strName . '_' . $id . '" class="tl_tree_radio" value="' . specialchars($id) . '" onfocus="Backend.getScrollOffset()"' . static::optionChecked($id, $this->varValue) . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['parentsUnselectable'] && !$this->isLeaf($objItem) ? ' disabled="disabled"' : '') . '>';
+                    $input = '<input type="radio" name="' . $this->strName . '" id="' . $this->strName . '_' . $id . '" class="tl_tree_radio" value="' . specialchars($id) . '" onfocus="Backend.getScrollOffset()"' . static::optionChecked($id, $this->varValue) . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['parentsUnselectable'] && $this->hasChildren($objItem) ? ' disabled="disabled"' : '') . '>';
                     break;
             }
 
@@ -464,11 +464,16 @@ class WidgetTreeSelector extends \Widget
         return $return;
     }
 
-    protected function isLeaf($objItem)
+    /**
+     * Determines whether an item has children items
+     * @param $objItem
+     * @return bool
+     */
+    protected function hasChildren($objItem)
     {
         $objChildren = $this->Database->prepare("SELECT id FROM $this->foreignTable WHERE pid=?")->execute($objItem->id);
 
-        return $objChildren->numRows <= 0;
+        return (int) $objChildren->numRows > 0;
     }
 
 

--- a/widgets/WidgetTreeSelector.php
+++ b/widgets/WidgetTreeSelector.php
@@ -426,12 +426,12 @@ class WidgetTreeSelector extends \Widget
             // Add checkbox or radio button
             switch ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['fieldType']) {
                 case 'checkbox':
-                    $input = '<input type="checkbox" name="' . $this->strName . '[]" id="' . $this->strName . '_' . $id . '" class="tl_tree_checkbox" value="' . specialchars($id) . '" onfocus="Backend.getScrollOffset()"' . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['selectParents'] ? ' onclick="TreePicker.selectParents(this)"' : '') . static::optionChecked($id, $this->varValue) . '>';
+                    $input = '<input type="checkbox" name="' . $this->strName . '[]" id="' . $this->strName . '_' . $id . '" class="tl_tree_checkbox" value="' . specialchars($id) . '" onfocus="Backend.getScrollOffset()"' . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['selectParents'] ? ' onclick="TreePicker.selectParents(this)"' : '') . static::optionChecked($id, $this->varValue) . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['parentsUnselectable'] && !$this->isLeaf($objItem) ? ' disabled="disabled"' : '') . '>';
                     break;
 
                 default:
                 case 'radio':
-                    $input = '<input type="radio" name="' . $this->strName . '" id="' . $this->strName . '_' . $id . '" class="tl_tree_radio" value="' . specialchars($id) . '" onfocus="Backend.getScrollOffset()"' . static::optionChecked($id, $this->varValue) . '>';
+                    $input = '<input type="radio" name="' . $this->strName . '" id="' . $this->strName . '_' . $id . '" class="tl_tree_radio" value="' . specialchars($id) . '" onfocus="Backend.getScrollOffset()"' . static::optionChecked($id, $this->varValue) . ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['parentsUnselectable'] && !$this->isLeaf($objItem) ? ' disabled="disabled"' : '') . '>';
                     break;
             }
 
@@ -462,6 +462,13 @@ class WidgetTreeSelector extends \Widget
         }
 
         return $return;
+    }
+
+    protected function isLeaf($objItem)
+    {
+        $objChildren = $this->Database->prepare("SELECT id FROM $this->foreignTable WHERE pid=?")->execute($objItem->id);
+
+        return $objChildren->numRows <= 0;
     }
 
 


### PR DESCRIPTION
Hi @qzminski ,

since we needed this feature, we added it to your module and would be happy if you accepted it. It's an additional option for disabling inputs of parent categories. In our case, it was only possible to select "leaf items".

Hoping for a merge ;-)

Bye Defcon0